### PR TITLE
Replace unpkg with jsDelivr, with SRI enabled

### DIFF
--- a/pio/index.html
+++ b/pio/index.html
@@ -6,7 +6,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
   <meta name="description" content="奇趣保罗的看板娘插件文档">
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
-  <link rel="stylesheet" href="//unpkg.com/docsify/lib/themes/vue.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsify@4.9.1/lib/themes/vue.css" integrity="sha256-QhW4Wo0hx+qd6ruaK4vJ6Li0ZdePlgSGMZfrZ9gKDtA=" crossorigin="anonymous">
   <style>#main h1{ margin-top: 2em; } section.cover p{ line-height: 1.5 }@media screen and (max-width: 600px){ #paul{ height: 0 } }</style>
 </head>
 <body>
@@ -27,7 +27,7 @@
       ]
     }
   </script>
-  <script src="//unpkg.com/docsify/lib/docsify.min.js"></script>
-  <script src="//cdn.jsdelivr.net/gh/Dreamer-Paul/Pio@2.1/static/l2d.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/docsify@4.9.1/lib/docsify.min.js" integrity="sha256-i4ldCcWDPFI2cpM/PU1wcuEVs+WjUaXlyAsEGl1BvXk=" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/gh/Dreamer-Paul/Pio@2.1/static/l2d.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Changes
- Replace CDN resources. From Unpkg to jsDelivr.
- Enable SRI for all constant assets.
- Force resources to use `https` protocol.

## Notices
- Please use the same asset codes for future the docsifies (like Single theme, Fantasy theme, etc).
- More assets on jsDelivr are to be found here: https://www.jsdelivr.com/package/npm/docsify
